### PR TITLE
Refactor Commands

### DIFF
--- a/ropa.d/os-package-install.sh
+++ b/ropa.d/os-package-install.sh
@@ -5,7 +5,7 @@
 # Copyright   : (c) 2025, Gergely Szabo
 # License     : MIT
 #
-# 'package_manager' global environment variable (defined in ropa.sh) holds the
+# 'PACKAGE_MANAGER' global environment variable (defined in ropa.sh) holds the
 # name of the system package manager executable. If the variable is emppty,
 # system_package_remove() will not be run.
 #
@@ -15,12 +15,12 @@
 system_package_install() {
   print_action "Attempting to install to system: $*"
 
-  # Choose the package manager command to run based on 'package_manager'.
+  # Choose the package manager command to run based on 'PACKAGE_MANAGER'.
   # After the command is run, the package manager's exit code is evaluated
   # to check if the installation was successful.
-  case "$package_manager" in
+  case "$PACKAGE_MANAGER" in
     apt|dnf|zypper)
-      sudo "$package_manager" install "$@"
+      sudo "$PACKAGE_MANAGER" install "$@"
 
       if [[ $? == "0" ]]; then
         print_success "Package(s) installed to system successfully."

--- a/ropa.d/os-package-remove.sh
+++ b/ropa.d/os-package-remove.sh
@@ -5,7 +5,7 @@
 # Copyright   : (c) 2025, Gergely Szabo
 # License     : MIT
 #
-# 'package_manager' global environment variable (defined in ropa.sh) holds the
+# 'PACKAGE_MANAGER' global environment variable (defined in ropa.sh) holds the
 # name of the system package manager executable. If the variable is emppty,
 # system_package_remove() will not be run.
 #
@@ -15,19 +15,19 @@
 system_package_remove() {
   print_action "Attempting to remove from system: $*"
 
-  # Choose the package manager command to run based on 'package_manager'.
+  # Choose the package manager command to run based on 'PACKAGE_MANAGER'.
   # After the command is run, the package manager's exit code is evaluated to
   # determine if the removal was successful. If it was, unused dependencies
   # are cleaned up; otherwise, an error message is printed.
-  case "$package_manager" in
+  case "$PACKAGE_MANAGER" in
     apt|dnf|zypper)
-      sudo "$package_manager" remove "$@"
+      sudo "$PACKAGE_MANAGER" remove "$@"
 
       if [[ $? == "0" ]]; then
         print_action "Cleaning up unused dependencies..."
-        case "$package_manager" in
+        case "$PACKAGE_MANAGER" in
           apt|dnf)
-            sudo "$package_manager" autoremove -y
+            sudo "$PACKAGE_MANAGER" autoremove -y
             ;;
           zypper)
             sudo zypper remove --clean-deps -y

--- a/ropa.d/os-package-sync.sh
+++ b/ropa.d/os-package-sync.sh
@@ -5,7 +5,7 @@
 # Copyright   : (c) 2025, Gergely Szabo
 # License     : MIT
 #
-# 'package_manager' global environment variable (defined in ropa.sh) holds the
+# 'PACKAGE_MANAGER' global environment variable (defined in ropa.sh) holds the
 # name of the system package manager executable. If the variable is emppty,
 # system_package_sync() will not be run.
 #
@@ -15,12 +15,12 @@
 system_package_sync() {
   print_action "Cleaning local repository indices..."
 
-  # Choose the package manager command to run based on 'package_manager':
+  # Choose the package manager command to run based on 'PACKAGE_MANAGER':
   # First, delete the local repository index data. Secondly, download the
   # fresh source repository index data, then evaluate the exit code to
   # check if the download was successful. Prompt if the download failed or
   # new updates are available.
-  case "$package_manager" in
+  case "$PACKAGE_MANAGER" in
     apt)
       sudo apt clean &>/dev/null
       print_success "Local repository indices have been cleaned."

--- a/ropa.d/os-package-update.sh
+++ b/ropa.d/os-package-update.sh
@@ -5,7 +5,7 @@
 # Copyright   : (c) 2025, Gergely Szabo
 # License     : MIT
 #
-# 'package_manager' global environment variable (defined in ropa.sh) holds the
+# 'PACKAGE_MANAGER' global environment variable (defined in ropa.sh) holds the
 # name of the system package manager executable. If the variable is emppty,
 # base_system_update() will not be run.
 #
@@ -43,12 +43,12 @@ system_package_update() {
   else
     print_action "Attempting to update: $*"
 
-    # Choose the package manager command to run based on 'package_manager'.
+    # Choose the package manager command to run based on 'PACKAGE_MANAGER'.
     # After the command is run, the package manager's exit code is evaluated
     # to check if the package update was successful.
-    case "$package_manager" in
+    case "$PACKAGE_MANAGER" in
       apt|dnf)
-        sudo "$package_manager" upgrade -y "$@"
+        sudo "$PACKAGE_MANAGER" upgrade -y "$@"
 
         if [[ $? == "0" ]]; then
           print_success "Package(s) updated successfully."
@@ -78,11 +78,11 @@ system_package_update() {
 system_package_update_full() {
   print_action "Searching for system package updates..."
 
-  # Choose the package manager command to run based on 'package_manager'.
+  # Choose the package manager command to run based on 'PACKAGE_MANAGER'.
   # After the command is run, the output is evaluated to determine if
   # there are any updates available. If there are, the updates are installed,
   # and unsued packages are removed.
-  case "$package_manager" in
+  case "$PACKAGE_MANAGER" in
     apt)
       sudo apt update &>/dev/null
       if [[ $(apt list --upgradable 2>/dev/null | wc -l) -gt 1 ]]; then

--- a/ropa.d/os-package-update.sh
+++ b/ropa.d/os-package-update.sh
@@ -16,13 +16,30 @@
 # TODO:
 #   - It would be nice to combine the two functions into one.
 
-# SINGLE OR MULTIPLE PACKAGE UPDATE FUNCTION
+# INDIVIDUAL PACKAGE UPDATE FUNCTION
 
-system_package_update_individual() {
-  # Fail if no package was specified.
+system_package_update() {
+  # If the user fails to specify package(s) to update,
+  # ask them what they want to do.
   if [[ -z "$*" ]]; then
     print_error "No package(s) specified for update."
-    return 1
+    print_warning "Do you want to update the operating system? [Y/n]"
+
+    read -r answer
+    case "$answer" in
+    # Default to Yes if the user presses Enter.
+      [Yy]|"")
+        system_package_update_full
+        ;;
+      [Nn])
+        print_error "Quitting."
+        return 1
+        ;;
+      *)
+        print_error "Invalid input. Aborting."
+        return 1
+        ;;
+    esac
   else
     print_action "Attempting to update: $*"
 
@@ -41,7 +58,7 @@ system_package_update_individual() {
         fi
         ;;
       zypper)
-        sudo zypper upgarde -y "$@"
+        sudo zypper update -y "$@"
 
         if [[ $? == "0" ]]; then
           print_success "Package(s) updated successfully."
@@ -52,7 +69,7 @@ system_package_update_individual() {
         ;;
     esac
   fi
-  
+
   return $?
 }
 

--- a/ropa.d/os-package-update.sh
+++ b/ropa.d/os-package-update.sh
@@ -24,10 +24,10 @@ system_package_update() {
   if [[ -z "$*" ]]; then
     print_error "No package(s) specified for update."
     print_warning "Do you want to update the operating system? [Y/n]"
-
     read -r answer
+
     case "$answer" in
-    # Default to Yes if the user presses Enter.
+      # Default to Yes if the user presses Enter.
       [Yy]|"")
         system_package_update_full
         ;;

--- a/ropa.d/os-package-update.sh
+++ b/ropa.d/os-package-update.sh
@@ -76,8 +76,6 @@ system_package_update() {
 # FULL SYSTEM UPDATE FUNCTION
 
 system_package_update_full() {
-  print_action "Searching for system package updates..."
-
   # Choose the package manager command to run based on 'PACKAGE_MANAGER'.
   # After the command is run, the output is evaluated to determine if
   # there are any updates available. If there are, the updates are installed,
@@ -85,6 +83,8 @@ system_package_update_full() {
   case "$PACKAGE_MANAGER" in
     apt)
       sudo apt update &>/dev/null
+      print_action "Searching for system package updates..."
+
       if [[ $(apt list --upgradable 2>/dev/null | wc -l) -gt 1 ]]; then
         print_action "Installing updates..."
         sudo apt upgrade -y
@@ -97,6 +97,8 @@ system_package_update_full() {
       ;;
     dnf)
       sudo dnf check-update &>/dev/null
+      print_action "Searching for system package updates..."
+
       if [[ $(dnf list updates 2>/dev/null | wc -l) -gt 1 ]]; then
         print_action "Installing updates..."
         sudo dnf upgrade -y
@@ -109,6 +111,8 @@ system_package_update_full() {
       ;;
     zypper)
       sudo zypper refresh &>/dev/null
+      print_action "Searching for system package updates..."
+
       if [[ $(zypper list-updates 2>/dev/null | wc -l) -gt 1 ]]; then
         print_action "Installing updates..."
         sudo zypper upgrade -y

--- a/ropa.d/os-package-update.sh
+++ b/ropa.d/os-package-update.sh
@@ -10,7 +10,7 @@
 # base_system_update() will not be run.
 #
 # Usage:
-#   ropa update|up <package> OR ropa update|up --all|-a
+#   ropa update|up <package> OR ropa update|up --full|-f
 #
 #
 # TODO:

--- a/ropa.d/print-messages.sh
+++ b/ropa.d/print-messages.sh
@@ -33,12 +33,12 @@ print_help() {
   echo -e "  \e[1;33mup\e[0m, \e[1;33mupdate\e[0m      Perform package update(s) -- see Options"
   echo -e "  \e[1;33m-h\e[0m, \e[1;33m--help\e[0m      Display this message"
   echo -e "\n\e[1;37mOptions:"
-  echo -e "  \e[0m('\e[1;33mup\e[0m' or '\e[1;33mupdate\e[0m')"
-  echo -e "  \e[1;34m-a\e[0m, \e[1;34m--all\e[0m       Performs full system update"
-  echo -e "  \e[1;34m-r\e[0m, \e[1;34m--rust\e[0m      Updates the Rust toolchain and Cargo packages only"
-  echo -e "  \e[1;34m-s\e[0m, \e[1;34m--system\e[0m    Updates the operating system only"
-  echo -e "  \e[1;34m-u\e[0m, \e[1;34m--universal\e[0m Updates universal package formats (Flatpaks, Snaps, etc.) only"
-  echo -e "  \e[0m<\e[1;34mpackage...\e[0m>    Updates a specific package or multiple packages"
+  echo -e "  \e[1;34m-a\e[0m, \e[1;34m--all\e[0m       Performs full system \e[1;33mupdate\e[0m"
+  echo -e "  \e[1;34m-r\e[0m, \e[1;34m--rust\e[0m      \e[1;33mUpdate\e[0m the Rust toolchain and Cargo packages only"
+  echo -e "  \e[1;34m-s\e[0m, \e[1;34m--system\e[0m    \e[1;33mUpdate\e[0m the operating system only"
+  echo -e "  \e[1;34m-u\e[0m, \e[1;34m--universal\e[0m \e[1;33mUpdate\e[0m universal package formats (Flatpaks, Snaps, etc.) only"
+  echo -e "\n\e[1;37mArguments:"
+  echo -e "  \e[0m<\e[1;34mpackage...\e[0m>    \e[1;33mInstall\e[0m, \e[1;33mremove\e[0m, or \e[1;33mupdate\e[0m the specified package(s)"
 
   return 0
 }

--- a/ropa.d/print-messages.sh
+++ b/ropa.d/print-messages.sh
@@ -33,10 +33,10 @@ print_help() {
   echo -e "  \e[1;33mup\e[0m, \e[1;33mupdate\e[0m      Perform package update(s) -- see Options"
   echo -e "  \e[1;33m-h\e[0m, \e[1;33m--help\e[0m      Display this message"
   echo -e "\n\e[1;37mOptions:"
-  echo -e "  \e[1;34m-a\e[0m, \e[1;34m--all\e[0m       Performs full system \e[1;33mupdate\e[0m"
+  echo -e "  \e[1;34m-a\e[0m, \e[1;34m--all\e[0m       Perform full system \e[1;33mupdate\e[0m"
   echo -e "  \e[1;34m-r\e[0m, \e[1;34m--rust\e[0m      \e[1;33mUpdate\e[0m the Rust toolchain and Cargo packages only"
   echo -e "  \e[1;34m-s\e[0m, \e[1;34m--system\e[0m    \e[1;33mUpdate\e[0m the operating system only"
-  echo -e "  \e[1;34m-u\e[0m, \e[1;34m--universal\e[0m \e[1;33mUpdate\e[0m universal package formats (Flatpaks, Snaps, etc.) only"
+  echo -e "  \e[1;34m-u\e[0m, \e[1;34m--universal\e[0m \e[1;33mUpdate\e[0m universal packages (Flatpaks, Snaps, etc.) only"
   echo -e "\n\e[1;37mArguments:"
   echo -e "  \e[0m<\e[1;34mpackage...\e[0m>    \e[1;33mInstall\e[0m, \e[1;33mremove\e[0m, or \e[1;33mupdate\e[0m the specified package(s)"
 

--- a/ropa.d/rust-package-update.sh
+++ b/ropa.d/rust-package-update.sh
@@ -10,6 +10,7 @@
 
 rust_package_update() {
   if command -v rustup &>/dev/null; then
+    print_action "Searching for Rust toolchain updates..."
 
     if [[ $(rustup update 2>/dev/null | wc -l) -gt 3 ]]; then
       print_action "Updating Rust toolchain..."

--- a/ropa.d/rust-package-update.sh
+++ b/ropa.d/rust-package-update.sh
@@ -29,6 +29,10 @@ rust_package_update() {
       cargo install $(cargo install --list | \
       grep -E '^[a-z0-9_-]+ v[0-9.]+:$' | \
       cut -f1 -d' ')
+      # Note: There is no way to properly catch and hide the output
+      # of "cargo install" in case of no available updates like with
+      # other type of package updates, so we just let the output
+      # print to the terminal.
       print_success "Cargo packages have been updated."
     else
       print_error "Cargo is not available: Cannot update packages."

--- a/ropa.sh
+++ b/ropa.sh
@@ -44,6 +44,10 @@ identify_system_package_manager() {
       # so it can be used by other functions and scripts.
       package_manager="$pm"
       export package_manager
+
+      # Break the loop once a valid package manager is found,
+      # since Linux distros typically use only one system package
+      # manager.
       break
     else
       print_error "A compatible package manager could not be identified."

--- a/ropa.sh
+++ b/ropa.sh
@@ -132,8 +132,8 @@ ropa() {
         --system|-s)
           system_package_update_full
           ;;
-        *)
         # Update individual packages.
+        *)
           shift
           system_package_update "$@"
           ;;

--- a/ropa.sh
+++ b/ropa.sh
@@ -135,7 +135,7 @@ ropa() {
         *)
         # Update individual packages.
           shift
-          system_package_update_individual "$@"
+          system_package_update "$@"
           ;;
       esac
       ;;

--- a/ropa.sh
+++ b/ropa.sh
@@ -31,9 +31,9 @@ done
 
 # SYSTEM PACKAGE MANAGER IDENTIFICATION
 
-identify_system_package_manager() {
+identify_system_PACKAGE_MANAGER() {
   declare -a package_managers=(apt dnf zypper)
-  package_manager=""
+  PACKAGE_MANAGER=""
 
   # Iterate through the array of package manager names to identify
   # if a system package manager command is executable.
@@ -42,8 +42,8 @@ identify_system_package_manager() {
       # Save the package manager executable name to a variable,
       # then export the variable as an environment variable,
       # so it can be used by other functions and scripts.
-      package_manager="$pm"
-      export package_manager
+      PACKAGE_MANAGER="$pm"
+      export PACKAGE_MANAGER
 
       # Break the loop once a valid package manager is found,
       # since Linux distros typically use only one system package
@@ -65,8 +65,8 @@ identify_system_package_manager() {
 # parsing. It is the main entry point for the ROPA CLI.
 ropa() {
   # Identify the system package manager before proceeding.
-  if [[ -z "$package_manager" ]]; then
-    identify_system_package_manager
+  if [[ -z "$PACKAGE_MANAGER" ]]; then
+    identify_system_PACKAGE_MANAGER
   fi
 
   # Command and Option Parsing

--- a/ropa.sh
+++ b/ropa.sh
@@ -115,7 +115,7 @@ ropa() {
     up|update)
       case "$option" in
         # Perform full system update.
-        --all|-a)
+        --full|-f)
           system_package_update_full && \
           universal_package_update && \
           rust_package_update

--- a/ropa.sh
+++ b/ropa.sh
@@ -16,7 +16,7 @@
 #   as a CLI command.
 #
 # Syntax:
-#   ropa [COMMAND...] [OPTION...]
+#   ropa [COMMAND...] [OPTION...] <package...>
 
 # LOAD THE ROPA ENVIRONMENT
 


### PR DESCRIPTION
### Add

- Prompt when searching for Rust toolchain updates.
- Comment why Cargo package updates are printed to the terminal when there are no available updates, unlike with other package managers.

### Change

- Command option `--all|-a` to `--full|-f`.
- Refactor `ropa update` behavior.
- Formatting of `ropa --help`.
- Change `package_manager` to `PACKAGE_MANAGER`.
- When performing system update (`ropa up --full|--system`), first prompt the user for the sudo password then print what the script is doing.

### Remove

- Minor code for cleanup.