### PR TITLE
Output update

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ source ~/.bashrc
 ## Usage & Syntax
 
 ```shell
-$ ropa [COMMAND...] [OPTION...]
+$ ropa [COMMAND...] [OPTION...] <package...>
 ```
 
 Run `ropa -h` or `ropa --help` to get a full overview of available commands and options.

--- a/ropa.d/go-package-update.sh
+++ b/ropa.d/go-package-update.sh
@@ -5,8 +5,6 @@
 # Copyright   : (c) 2025, Gergely Szabo
 # License     : MIT
 #
-# THIS FEATURE IS EXPERIMENTAL AND MAY NOT WORK AS EXPECTED!
-#
 # The script currently only supports non-root installations, for example: ~/go
 # or ~/.local/share/go.
 #

--- a/ropa.d/go-package-update.sh
+++ b/ropa.d/go-package-update.sh
@@ -13,7 +13,8 @@
 
 go_package_update() {
   # Fail silenty if called via 'ropa update --full'.
-  if [[ "$option" == "--full" || "$option" == "-f" ]]; then
+  if [[ -z "$(command -v go)" && "$option" == "--full" ]] || \
+  [[ -z "$(command -v go)" && "$option" == "-f" ]]; then
     return 0
   fi
 

--- a/ropa.d/go-package-update.sh
+++ b/ropa.d/go-package-update.sh
@@ -14,48 +14,46 @@
 #   ropa update|up --go|-g
 
 go_package_update() {
-  if command -v go &>/dev/null; then
+  # Fail silenty if called via 'ropa update --full'.
+  if [[ "$option" == "--full" || "$option" == "-f" ]]; then
+    return 0
+  fi
 
-    # Skip updates if Go is installed to /usr/local/ (officially recommended).
+  if command -v go &>/dev/null; then
     if [[ "$(command -v go)" == "/usr/local/go/bin/go" ]]; then
-      print_warning "Detected system-wide installation of Go toolchain. These are not supported right now, skipping updates."
+      print_warn "Detected system-wide installation of Go toolchain. These are not supported right now, skipping updates."
       return 0
     fi
 
-    print_action "Searching for Go toolchain updates..."
-
-    # Initialize the Go environment variables.
     GO_VERSION="$(go version | awk '{print $3}' | sed 's/go//')"
     GO_INSTALL_DIR="$(command -v go | sed 's|/go.*$||')"
     GO_LATEST_VER="$(curl -s https://go.dev/VERSION?m=text | grep -oP 'go\K[0-9.]+')"
 
-    # Check for updates & download the latest Go version.
+    print_step "Searching for Go toolchain updates..."
     if [[ "$GO_VERSION" == "$GO_LATEST_VER" ]]; then
-      print_success "No available Go toolchain updates."
+      print_info "No available Go toolchain updates."
     else
-      print_action "Updating Go toolchain..."
+      print_step "Updating Go toolchain..."
       wget "https://go.dev/dl/go$GO_LATEST_VER.linux-amd64.tar.gz" -O /tmp/go.tar.gz
 
       if [[ $? != 0 ]]; then
-        print_error "Failed to download the latest Go version. Please check the output for details."
+        print_err "Failed to download the latest Go version. Please check the output for details."
         return 1
       fi
 
-      # Remove current installation before installing new version.
+      # Remove current installation before installing the new version.
       rm -rf "$GO_INSTALL_DIR/go" &>/dev/null
-
-      # Install the new Go version.
       tar -C "$GO_INSTALL_DIR" -xzf /tmp/go.tar.gz
 
       if [[ $? == 0 ]]; then
-        print_success "Go toolchain has been updated."
+        print_info "Go toolchain has been updated."
       else
-        print_error "Failed to update Go. Please check the output for details."
+        print_err "Failed to update Go. Please check the output for details."
         return 1
       fi
     fi
   else
-    print_warning "Go toolchain is not installed. Skipping updates."
+    print_warn "Go toolchain is not installed. Skipping updates."
     return 0
   fi
 

--- a/ropa.d/os-package-install.sh
+++ b/ropa.d/os-package-install.sh
@@ -13,20 +13,14 @@
 #   ropa install|in <package>
 
 system_package_install() {
-  print_action "Attempting to install to system: $*"
-
-  # Choose the package manager command to run based on 'PACKAGE_MANAGER'.
-  # After the command is run, the package manager's exit code is evaluated
-  # to check if the installation was successful.
   case "$PACKAGE_MANAGER" in
     apt|dnf|zypper)
+      print_action "Attempting to install to system: $*"
       sudo "$PACKAGE_MANAGER" install "$@"
 
-      if [[ $? == "0" ]]; then
-        print_success "Package(s) installed to system successfully."
-      else
-        print_error "Package installation(s) failed."
-        print_error "Please check the output of your package manager for details."
+      if [[ $? != "0" ]]; then
+        print_err "There was an error while installing package(s)."
+        print_err "Please check the output of your package manager for details."
         return $?
       fi
       ;;

--- a/ropa.d/os-package-remove.sh
+++ b/ropa.d/os-package-remove.sh
@@ -13,18 +13,16 @@
 #   ropa remove|rm <package>
 
 system_package_remove() {
-  print_action "Attempting to remove from system: $*"
-
-  # Choose the package manager command to run based on 'PACKAGE_MANAGER'.
-  # After the command is run, the package manager's exit code is evaluated to
-  # determine if the removal was successful. If it was, unused dependencies
-  # are cleaned up; otherwise, an error message is printed.
   case "$PACKAGE_MANAGER" in
     apt|dnf|zypper)
+      print_action "Attempting to remove from system: $*"
       sudo "$PACKAGE_MANAGER" remove "$@"
 
-      if [[ $? == "0" ]]; then
-        print_action "Cleaning up unused dependencies..."
+      if [[ $? != "0" ]]; then
+        print_err "There was an error while removing package(s)."
+        print_err "Please check the output of your package manager for details."
+        return $?
+      else
         case "$PACKAGE_MANAGER" in
           apt|dnf)
             sudo "$PACKAGE_MANAGER" autoremove -y
@@ -33,13 +31,7 @@ system_package_remove() {
             sudo zypper remove --clean-deps -y
             ;;
         esac
-        print_success "Package(s) removed from the system successfully."
-      else
-        print_error "Package removal(s) failed."
-        print_error "Please check the output of your package manager for details."
-        return $?
       fi
-      ;;
   esac
 
   return $?

--- a/ropa.d/os-package-sync.sh
+++ b/ropa.d/os-package-sync.sh
@@ -13,84 +13,58 @@
 #   ropa sync|sy
 
 system_package_sync() {
-  print_action "Cleaning local repository indices..."
-
-  # Choose the package manager command to run based on 'PACKAGE_MANAGER':
-  # First, delete the local repository index data. Secondly, download the
-  # fresh source repository index data, then evaluate the exit code to
-  # check if the download was successful. Prompt if the download failed or
-  # new updates are available.
+  # 'PACKAGE_MANAGER' is an environmental variable set
+  # by identify_system_package_manager().
   case "$PACKAGE_MANAGER" in
     apt)
+      print_step "Syncing local repository indices with remote sources..."
       sudo apt clean &>/dev/null
-      print_success "Local repository indices have been cleaned."
-
-      print_action "Downloading latest repository indices from configured sources..."
       sudo apt update
 
-      if [[ $? == "0" ]]; then
-        print_success "Package database indices have been updated."
-
-        # Prompt if updates are available
-        sudo apt update &>/dev/null
-        if [[ $(apt list --upgradable 2>/dev/null | wc -l) -gt 1 ]]; then
-          print_warning "Updates are available for your system packages."
-          print_warning "Run '\e[1;33mropa up\e[1;37m' or '\e[1;33mropa update\e[1;37m' to install them."
-        else
-          print_success "Your system is already up-to-date, nothing to update."
-        fi
-      else
-        print_error "Failed to update repository indices."
-        print_error "Please check the output of your package manager for details."
+      if [[ $? != "0" ]]; then
+        print_err "There was an error while syncing the repository indices."
+        print_err "Please check the output of your package manager for details."
         return $?
+      fi
+
+      # Prompt if updates are available.
+      if [[ $(apt list --upgradable 2>/dev/null | wc -l) -gt 1 ]]; then
+        print_warn "Updates are available for your system packages."
+        print_info "Run '\e[1;33mropa up\e[1;37m' or '\e[1;33mropa update\e[1;37m' to install them."
       fi
       ;;
     dnf)
+      print_step "Syncing local repository indices with remote sources..."
       sudo dnf clean all &>/dev/null
-      print_success "Local repository indices have been cleaned."
-
-      print_action "Downloading latest repository indices from configured sources..."
       sudo dnf check-update
 
-      if [[ $? == "0" ]]; then
-        print_success "Package database indices have been updated."
-
-        # Prompt if updates are available
-        sudo dnf check-update &>/dev/null
-        if [[ $(dnf list updates 2>/dev/null | wc -l) -gt 1 ]]; then
-          print_warning "Updates are available for your system packages."
-          print_warning "Run '\e[1;33mropa up\e[1;37m' or '\e[1;33mropa update\e[1;37m' to install them."
-        else
-          print_success "Your system is already up-to-date, nothing to update."
-        fi
-      else
-        print_error "Failed to update repository indices."
-        print_error "Please check the output of your package manager for details."
+      if [[ $? != "0" ]]; then
+        print_err "There was an error while syncing the repository indices."
+        print_err "Please check the output of your package manager for details."
         return $?
+      fi
+
+      # Prompt if updates are available.
+      if [[ $(dnf list updates 2>/dev/null | wc -l) -gt 1 ]]; then
+        print_warn "Updates are available for your system packages."
+        print_info "Run '\e[1;33mropa up\e[1;37m' or '\e[1;33mropa update\e[1;37m' to install them."
       fi
       ;;
     zypper)
+      print_step "Syncing local repository indices with remote sources..."
       sudo zypper clean &>/dev/null
-      print_success "Local repository indices have been cleaned."
-
-      print_action "Downloading latest repository indices from configured sources..."
       sudo zypper refresh
 
-      if [[ $? == "0" ]]; then
-        print_success "Package database indices have been updated."
-
-        # Prompt if updates are available
-        sudo zypper refresh &>/dev/null
-        if [[ $(zypper list-updates 2>/dev/null | wc -l) -gt 1 ]]; then
-          print_warning "Updates are available for your system packages."
-          print_warning "Run '\e[1;33mropa up\e[1;37m' or '\e[1;33mropa update\e[1;37m' to install them."
-        else
-          print_success "Your system is already up-to-date, nothing to update."
-        fi
-      else
-        print_error "Failed to update repository indices."
-        print_error "Please check the output of your package manager for details."
+      if [[ $? != "0" ]]; then
+        print_err "There was an error while syncing the repository indices."
+        print_err "Please check the output of your package manager for details."
         return $?
+      fi
+
+      # Prompt if updates are available
+      if [[ $(zypper list-updates 2>/dev/null | wc -l) -gt 1 ]]; then
+        print_warn "Updates are available for your system packages."
+        print_info "Run '\e[1;33mropa up\e[1;37m' or '\e[1;33mropa update\e[1;37m' to install them."
       fi
       ;;
   esac

--- a/ropa.d/os-package-update.sh
+++ b/ropa.d/os-package-update.sh
@@ -16,14 +16,16 @@
 # TODO:
 #   - It would be nice to combine the two functions into one.
 
-# INDIVIDUAL PACKAGE UPDATE FUNCTION
+##
+## INDIVIDUAL PACKAGE UPDATE FUNCTION
+##
 
 system_package_update() {
   # If the user fails to specify package(s) to update,
   # ask them what they want to do.
   if [[ -z "$*" ]]; then
-    print_error "No package(s) specified for update."
-    print_warning "Do you want to update the operating system? [Y/n]"
+    print_err "No package(s) specified for update."
+    print_warn "Do you want to update the operating system? [Y/n]"
     read -r answer
 
     case "$answer" in
@@ -32,39 +34,32 @@ system_package_update() {
         system_package_update_full
         ;;
       [Nn])
-        print_error "Quitting."
+        print_err "Quitting."
         return 1
         ;;
       *)
-        print_error "Invalid input. Aborting."
+        print_err "Invalid input. Aborting."
         return 1
         ;;
     esac
   else
-    print_action "Attempting to update: $*"
+    print_step "Attempting to update: $*"
 
-    # Choose the package manager command to run based on 'PACKAGE_MANAGER'.
-    # After the command is run, the package manager's exit code is evaluated
-    # to check if the package update was successful.
     case "$PACKAGE_MANAGER" in
       apt|dnf)
         sudo "$PACKAGE_MANAGER" upgrade -y "$@"
 
-        if [[ $? == "0" ]]; then
-          print_success "Package(s) updated successfully."
-        else
-          print_error "Package update(s) failed."
-          print_error "Please check the output of your package manager for details."
+        if [[ $? != "0" ]]; then
+          print_err "Package update(s) failed."
+          print_err "Please check the output of your package manager for details."
         fi
         ;;
       zypper)
         sudo zypper update -y "$@"
 
-        if [[ $? == "0" ]]; then
-          print_success "Package(s) updated successfully."
-        else
-          print_error "Package update(s) failed."
-          print_error "Please check the output of your package manager for details."
+        if [[ $? != "0" ]]; then
+          print_err "Package update(s) failed."
+          print_err "Please check the output of your package manager for details."
         fi
         ;;
     esac
@@ -73,54 +68,46 @@ system_package_update() {
   return $?
 }
 
-# FULL SYSTEM UPDATE FUNCTION
+##
+## FULL SYSTEM UPDATE FUNCTION
+##
 
 system_package_update_full() {
-  # Choose the package manager command to run based on 'PACKAGE_MANAGER'.
-  # After the command is run, the output is evaluated to determine if
-  # there are any updates available. If there are, the updates are installed,
-  # and unsued packages are removed.
   case "$PACKAGE_MANAGER" in
     apt)
+      print_step "Searching for system package updates..."
       sudo apt update &>/dev/null
-      print_action "Searching for system package updates..."
 
       if [[ $(apt list --upgradable 2>/dev/null | wc -l) -gt 1 ]]; then
-        print_action "Installing updates..."
+        print_step "Installing updates..."
         sudo apt upgrade -y
-        print_action "Cleaning up packages..."
         sudo apt autoremove -y
-        print_success "System packages have been updated."
       else
-        print_success "No available system updates."
+        print_info "No available system updates."
       fi
       ;;
     dnf)
-      sudo dnf check-update &>/dev/null
       print_action "Searching for system package updates..."
+      sudo dnf check-update &>/dev/null
 
       if [[ $(dnf list updates 2>/dev/null | wc -l) -gt 1 ]]; then
-        print_action "Installing updates..."
+        print_step "Installing updates..."
         sudo dnf upgrade -y
-        print_action "Cleaning up packages..."
         sudo dnf autoremove -y
-        print_success "System packages have been updated."
       else
-        print_success "No available system updates."
+        print_info "No available system updates."
       fi
       ;;
     zypper)
+      print_step "Searching for system package updates..."
       sudo zypper refresh &>/dev/null
-      print_action "Searching for system package updates..."
 
       if [[ $(zypper list-updates 2>/dev/null | wc -l) -gt 1 ]]; then
-        print_action "Installing updates..."
+        print_step "Installing updates..."
         sudo zypper upgrade -y
-        print_action "Cleaning up packages..."
         sudo zypper remove
-        print_success "System packages have been updated."
       else
-        print_success "No available system updates."
+        print_info "No available system updates."
       fi
       ;;
   esac

--- a/ropa.d/os-package-update.sh
+++ b/ropa.d/os-package-update.sh
@@ -81,6 +81,7 @@ system_package_update_full() {
       if [[ $(apt list --upgradable 2>/dev/null | wc -l) -gt 1 ]]; then
         print_step "Installing updates..."
         sudo apt upgrade -y
+        print_step "Cleaning up..."
         sudo apt autoremove -y
       else
         print_info "No available system updates."
@@ -93,6 +94,7 @@ system_package_update_full() {
       if [[ $(dnf list updates 2>/dev/null | wc -l) -gt 1 ]]; then
         print_step "Installing updates..."
         sudo dnf upgrade -y
+        print_step "Cleaning up..."
         sudo dnf autoremove -y
       else
         print_info "No available system updates."
@@ -105,6 +107,7 @@ system_package_update_full() {
       if [[ $(zypper list-updates 2>/dev/null | wc -l) -gt 1 ]]; then
         print_step "Installing updates..."
         sudo zypper upgrade -y
+        print_step "Cleaning up..."
         sudo zypper remove
       else
         print_info "No available system updates."

--- a/ropa.d/print-messages.sh
+++ b/ropa.d/print-messages.sh
@@ -5,23 +5,23 @@
 # Copyright   : (c) 2025, Gergely Szabo
 # License     : MIT
 
-print_action() {
+print_step() {
   echo -e "\e[1;34m=> \e[1;37m$1\e[0m" >&1
 }
 
-print_success() {
+print_msg() {
   echo -e "\e[1;32m:: \e[1;37m$1\e[0m" >&1
 }
 
-print_warning() {
+print_warn() {
   echo -e "\e[1;33m:: \e[1;37m$1\e[0m" >&1
 }
 
-print_error() {
+print_err() {
   echo -e "\e[1;31m:: \e[1;37m$1\e[0m" >&2
 }
 
-print_help() {
+help() {
   echo -e "ROPA -- ROsetta Package Assistant -- is NOT a package manager. It is a front-end"
   echo -e "wrapper for GNU/Linux distributions providing a consistent and simplified"
   echo -e "command-line interface."

--- a/ropa.d/print-messages.sh
+++ b/ropa.d/print-messages.sh
@@ -9,7 +9,7 @@ print_step() {
   echo -e "\e[1;34m=> \e[1;37m$1\e[0m" >&1
 }
 
-print_msg() {
+print_info() {
   echo -e "\e[1;32m:: \e[1;37m$1\e[0m" >&1
 }
 

--- a/ropa.d/rust-package-update.sh
+++ b/ropa.d/rust-package-update.sh
@@ -10,7 +10,8 @@
 
 rust_package_update() {
   # Fail silenty if called via 'ropa update --full'.
-  if [[ "$option" == "--full" || "$option" == "-f" ]]; then
+  if [[ -z "$(command -v rustup)" && "$option" == "--full" ]] || \
+  [[ -z "$(command -v rustup)" && "$option" == "-f" ]]; then
     return 0
   fi
 

--- a/ropa.d/rust-package-update.sh
+++ b/ropa.d/rust-package-update.sh
@@ -9,6 +9,11 @@
 #   ropa update|up --rust|-r
 
 rust_package_update() {
+  # Fail silenty if called via 'ropa update --full'.
+  if [[ "$option" == "--full" || "$option" == "-f" ]]; then
+    return 0
+  fi
+
   if command -v rustup &>/dev/null; then
     print_step "Searching for Rust toolchain updates..."
 

--- a/ropa.d/rust-package-update.sh
+++ b/ropa.d/rust-package-update.sh
@@ -10,18 +10,17 @@
 
 rust_package_update() {
   if command -v rustup &>/dev/null; then
-    print_action "Searching for Rust toolchain updates..."
+    print_step "Searching for Rust toolchain updates..."
 
     if [[ $(rustup update 2>/dev/null | wc -l) -gt 3 ]]; then
-      print_action "Updating Rust toolchain..."
+      print_step "Installing updates..."
       rustup update
-      print_success "Rust toolchain has been updated."
     else
-      print_success "No available Rust toolchain updates."
+      print_info "No available Rust toolchain updates."
     fi
 
     if command -v cargo &>/dev/null; then
-      print_action "Updating Cargo packages..."
+      print_step "Searching for Cargo package updates..."
 
       # Vanilla Rust doesn't have a "cargo update" equivalent.
       # The method of updating installed packages is using
@@ -29,17 +28,12 @@ rust_package_update() {
       cargo install $(cargo install --list | \
       grep -E '^[a-z0-9_-]+ v[0-9.]+:$' | \
       cut -f1 -d' ')
-      # Note: There is no way to properly catch and hide the output
-      # of "cargo install" in case of no available updates like with
-      # other type of package updates, so we just let the output
-      # print to the terminal.
-      print_success "Cargo packages have been updated."
     else
-      print_error "Cargo is not available: Cannot update packages."
+      print_err "Cargo is not available: Cannot update packages."
       return 1
     fi
   else
-    print_warning "Rust toolchain is not installed. Skipping updates."
+    print_warn "Rust toolchain is not installed. Skipping updates."
   fi
 
   return $?

--- a/ropa.d/universal-package-update.sh
+++ b/ropa.d/universal-package-update.sh
@@ -43,7 +43,7 @@ universal_package_update() {
     fi
   done
 
-  if [[ "$found_universal_pm" = false ]]; then
+  if [[ "$found_universal_pm" == false ]]; then
     print_warn "No universal package manager was found. Skipping updates."
   fi
 

--- a/ropa.d/universal-package-update.sh
+++ b/ropa.d/universal-package-update.sh
@@ -31,7 +31,7 @@ universal_package_update() {
 
       if command -v flatpak &>/dev/null; then
         print_step "Searching for Flatpak updates..."
-        flatpak update -y | grep -v '^Looking for updates\…$'
+        flatpak update -y
         flatpak remove --unused -y
       fi
 

--- a/ropa.d/universal-package-update.sh
+++ b/ropa.d/universal-package-update.sh
@@ -32,12 +32,14 @@ universal_package_update() {
       if command -v flatpak &>/dev/null; then
         print_step "Searching for Flatpak updates..."
         flatpak update -y
+        print_step "Cleaning up..."
         flatpak remove --unused -y
       fi
 
       if command -v brew &>/dev/null; then
         print_step "Searching for Homebrew updates..."
         brew update
+        print_step "Cleaning up..."
         brew cleanup
       fi
     fi

--- a/ropa.d/universal-package-update.sh
+++ b/ropa.d/universal-package-update.sh
@@ -24,42 +24,27 @@ universal_package_update() {
       found_universal_pm=true
 
       if command -v snap &>/dev/null; then
-        print_action "Searching for Snap updates..."
+        print_step "Searching for Snap updates..."
         sudo snap refresh
         echo "Snap packages are up-to-date."
       fi
 
       if command -v flatpak &>/dev/null; then
-        print_action "Searching for Flatpak updates..."
-        if [[ $(flatpak update | tee /dev/null | wc -l) -gt 3 ]] && \
-          # Ignore "end-of-life" runtime warnings.
-          flatpak update | grep -q '^Nothing to do.'; then
-          print_success "No available Flatpak updates."
-        else
-          print_action "Installing updates..."
-          flatpak update -y
-          print_action "Cleaning up packages..."
-          flatpak remove --unused -y
-          print_success "Flatpak packages have been updated."
-        fi
+        print_step "Searching for Flatpak updates..."
+        flatpak update -y | grep -v '^Looking for updates\…$'
+        flatpak remove --unused -y
       fi
 
       if command -v brew &>/dev/null; then
-        print_action "Searching for Homebrew updates..."
-        brew update 2>/dev/null
-        if [[ $(brew outdated --formula | wc -l) -gt 0 ]]; then
-          print_action "Cleaning up packages..."
-          brew cleanup
-          print_success "Homebrew packages have been updated."
-        else
-          print_success "No available Homebrew updates."
-        fi
+        print_step "Searching for Homebrew updates..."
+        brew update
+        brew cleanup
       fi
     fi
   done
 
   if [[ "$found_universal_pm" = false ]]; then
-    print_warning "No universal package manager was found. Skipping updates."
+    print_warn "No universal package manager was found. Skipping updates."
   fi
 
   return $?

--- a/ropa.sh
+++ b/ropa.sh
@@ -31,7 +31,7 @@ done
 
 # SYSTEM PACKAGE MANAGER IDENTIFICATION
 
-identify_system_PACKAGE_MANAGER() {
+identify_system_package_manager() {
   declare -a package_managers=(apt dnf zypper)
   PACKAGE_MANAGER=""
 
@@ -66,7 +66,7 @@ identify_system_PACKAGE_MANAGER() {
 ropa() {
   # Identify the system package manager before proceeding.
   if [[ -z "$PACKAGE_MANAGER" ]]; then
-    identify_system_PACKAGE_MANAGER
+    identify_system_package_manager
   fi
 
   # Command and Option Parsing

--- a/ropa.sh
+++ b/ropa.sh
@@ -132,7 +132,6 @@ ropa() {
           rust_package_update
           ;;
         # Update the Go toolchain only.
-        # Note: EXPERINMENTAL FEATURE!
         --go|-g)
           go_package_update
           ;;

--- a/ropa.sh
+++ b/ropa.sh
@@ -18,7 +18,9 @@
 # Syntax:
 #   ropa [COMMAND...] [OPTION...] <package...>
 
-# LOAD THE ROPA ENVIRONMENT
+##
+## LOAD THE ROPA ENVIRONMENT
+##
 
 # Load all files with .sh exentsion from the ropa.d directory. ropa.d is
 # expected to be in the same directory as this script.
@@ -29,7 +31,9 @@ for file in "$ropa_dir"/*.sh; do
   fi
 done
 
-# SYSTEM PACKAGE MANAGER IDENTIFICATION
+##
+## SYSTEM PACKAGE MANAGER IDENTIFICATION
+##
 
 identify_system_package_manager() {
   declare -a package_managers=(apt dnf zypper)
@@ -59,7 +63,9 @@ identify_system_package_manager() {
   return 0
 }
 
-# MAIN FUNCTION
+##
+## MAIN FUNCTION
+##
 
 # This function exposes the ROPA command-line interface with command and option
 # parsing. It is the main entry point for the ROPA CLI.

--- a/ropa.sh
+++ b/ropa.sh
@@ -50,8 +50,8 @@ identify_system_PACKAGE_MANAGER() {
       # manager.
       break
     else
-      print_error "A compatible package manager could not be identified."
-      print_error "Verify your package manager is in your PATH, and supported by ROPA."
+      print_err "A compatible package manager could not be identified."
+      print_err "Verify your package manager is in your PATH, and supported by ROPA."
       return 1
     fi
   done
@@ -75,13 +75,13 @@ ropa() {
 
   case "$command" in
     -h|--help)
-      print_help
+      help
       ;;
     in|install)
       case "$option" in
         # Fail if no package name is specified.
         "")
-          print_error "No package(s) specified for installation."
+          print_err "No package(s) specified for installation."
           return 1
           ;;
         *)
@@ -94,7 +94,7 @@ ropa() {
       case "$option" in
         # Fail if no package name is specified.
         "")
-          print_error "No package(s) specified for removal."
+          print_err "No package(s) specified for removal."
           return 1
           ;;
         *)
@@ -110,8 +110,8 @@ ropa() {
           system_package_sync
           ;;
         *)
-          print_error "Invalid option: $2"
-          print_error "Use '\e[1;33m-h\e[1;37m' or '\e[1;33m--help\e[1;37m' for available options."
+          print_err "Invalid option: $2"
+          print_err "Use '\e[1;33m-h\e[1;37m' or '\e[1;33m--help\e[1;37m' for available options."
           return 1
           ;;
       esac
@@ -150,8 +150,8 @@ ropa() {
       esac
       ;;
     *)
-      print_error "Invalid command: $1"
-      print_error "Use '\e[1;33m-h\e[1;37m' or '\e[1;33m--help\e[1;37m' for available commands."
+      print_err "Invalid command: $1"
+      print_err "Use '\e[1;33m-h\e[1;37m' or '\e[1;33m--help\e[1;37m' for available commands."
       return 1
       ;;
   esac


### PR DESCRIPTION
### Add

- A conditional check for Go and Rust toolchain updates, so no prompt saying "Skipping updates..." is displayed when running `ropa update --full` and one or both of these toolchains aren't installed.

### Change

- Shorten the print function names.
- Fix typos.
- Change code section headers (comments).
- Remove some print spam, and reply more on the output of the package managers.
- Code fixes.
- Update docs.

### Remove

- Unnecessary comments that were duplicating the code.
- Experimental message for Go toolchain update function.